### PR TITLE
Core: Change how default role permission works

### DIFF
--- a/backend/src/api/v1/role.route.js
+++ b/backend/src/api/v1/role.route.js
@@ -109,6 +109,7 @@ router.patch(
         perm('role').can('modify'),
         param('role_tag').custom(checkRoleTag),
         // body('mode').custom(value => ['grant', 'deny'].includes(value)),
+        body('name').isString(),
         body('perms').isArray(),
         validateParams,
     ],
@@ -132,6 +133,9 @@ router.patch(
                 throw err
             }
         }
+
+        // 역할 name 변경
+        roles.getRole(req.params.role_tag).name = req.body.name
 
         // 수정할 데이터를 Role 에 반영
         const context = roles.role(req.params.role_tag)

--- a/backend/src/api/v1/user.route.js
+++ b/backend/src/api/v1/user.route.js
@@ -120,6 +120,12 @@ router.put(
             }
         }
 
+        if (req.body.roletags.include('default')) {
+            const err = new Error('default 역할은 변경할 수 없습니다.')
+            err.status = 403
+            throw err
+        }
+
         user.roles = req.body.roletags
         await user.save()
         clearCache('USER-ROLE-' + req.user.username)
@@ -148,6 +154,12 @@ router.post(
             throw err
         }
 
+        if (req.body.roletag == 'default') {
+            const err = new Error('default 역할은 변경할 수 없습니다.')
+            err.status = 403
+            throw err
+        }
+
         if (user.roles.indexOf(req.body.roletag) == -1) {
             user.roles.push(req.body.roletag)
             await user.save()
@@ -160,7 +172,7 @@ router.post(
 router.delete(
     '/:username/role/:roletag',
     [
-        role.perm('role', 'user').can('delete'),
+        role.perm('role').can('modify'),
         param('username').custom(checkUsername),
         param('roletag').custom(checkRoleTag),
         validateParams,

--- a/backend/src/utils/role/default.js
+++ b/backend/src/utils/role/default.js
@@ -1,6 +1,7 @@
 export function setDefaultRole(roles) {
+    roles.setRole({ tag: 'default', name: '모든 유저' })
     roles
-        .default()
+        .role('default')
 
         .resource('profile')
         .canOwn('read')
@@ -23,7 +24,7 @@ export function setDefaultRole(roles) {
 }
 
 export function setAdminRole(roles) {
-    roles.setRole({ tag: 'admin', name: 'admin' })
+    roles.setRole({ tag: 'admin', name: '관리자' })
     roles
         .role('admin')
 

--- a/backend/src/utils/role/index.js
+++ b/backend/src/utils/role/index.js
@@ -68,7 +68,7 @@ const role = {
         }
     },
     async getRoleNames() {
-        return roles.roleNames()
+        return roles.roleNames().sort((a, b) => a.name.localeCompare(b.name))
     },
     async createRole({ name }) {
         let newtag

--- a/backend/src/utils/role/index.js
+++ b/backend/src/utils/role/index.js
@@ -15,7 +15,7 @@ const role = {
                 .equals(req.user.username)
                 .select('roles')
                 .cache(60, 'USER-ROLE-' + req.user.username)
-            req.user.perm = roles.createPermChecker(user.roles)
+            req.user.perm = roles.createPermChecker(['default', ...user.roles])
             next()
         } else {
             next()
@@ -57,7 +57,6 @@ const role = {
     },
     permOr(callback) {
         return (req, res, next) => {
-            console.log(callback(req.user.perm))
             if (callback(req.user.perm)) {
                 next()
             } else {
@@ -68,7 +67,7 @@ const role = {
         }
     },
     async getRoleNames() {
-        return roles.roleNames().sort((a, b) => a.name.localeCompare(b.name))
+        return roles.roleNames()
     },
     async createRole({ name }) {
         let newtag
@@ -128,14 +127,27 @@ const role = {
     },
     async loadRoles() {
         const roleobjs = await RoleModel.find()
+        let hasDefault = false
         roleobjs.forEach(role => {
+            if (role.tag === 'default') {
+                hasDefault = true
+            }
             roles.setRole({
                 tag: role.tag,
                 name: role.name,
                 perm: role.perm,
             })
         })
-        setDefaultRole(roles)
+        if (!hasDefault) {
+            setDefaultRole(roles)
+            const newrole = roles.export('default')
+            const newroledoc = RoleModel({
+                tag: newrole.tag,
+                name: newrole.name,
+                perm: newrole.perm,
+            })
+            await newroledoc.save()
+        }
         setAdminRole(roles)
     },
     async getUserRoles(username) {

--- a/frontend/src/components/layout/General.vue
+++ b/frontend/src/components/layout/General.vue
@@ -4,7 +4,7 @@
             <side-menu></side-menu>
         </v-navigation-drawer>
 
-        <v-app-bar app clipped-left>
+        <v-app-bar app clipped-left elevation="2">
             <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
             <v-btn text large @click="$router.push('/')">
                 <v-toolbar-title>{{

--- a/frontend/src/components/manage/RolePermEdit.vue
+++ b/frontend/src/components/manage/RolePermEdit.vue
@@ -26,7 +26,7 @@
                     placeholder="역할 이름"
                     outlined
                     hide-details
-                    :disabled="permdisabled"
+                    :disabled="infodisabled"
                     @input="changed = true"
                 ></v-text-field>
             </v-list-item>
@@ -38,7 +38,7 @@
                     tile
                     color="error"
                     @click="showRemoveRoleDialog"
-                    :disabled="permdisabled"
+                    :disabled="infodisabled"
                     >역할 삭제</v-btn
                 >
             </v-list-item>
@@ -124,6 +124,9 @@ export default {
     computed: {
         permdisabled() {
             return this.roletag === 'admin' || this.disabled
+        },
+        infodisabled() {
+            return ['admin', 'default'].includes(this.roletag) || this.disabled
         },
     },
     methods: {

--- a/frontend/src/components/manage/RolePermEdit.vue
+++ b/frontend/src/components/manage/RolePermEdit.vue
@@ -26,6 +26,7 @@
                     placeholder="역할 이름"
                     outlined
                     hide-details
+                    :disabled="permdisabled"
                     @input="changed = true"
                 ></v-text-field>
             </v-list-item>
@@ -37,7 +38,7 @@
                     tile
                     color="error"
                     @click="showRemoveRoleDialog"
-                    :disabled="disabled"
+                    :disabled="permdisabled"
                     >역할 삭제</v-btn
                 >
             </v-list-item>
@@ -192,6 +193,8 @@ export default {
 
         async savePerms() {
             this.isLoading = true
+
+            // 권한 수정 목록 구축
             const perms = []
             for (let key of Object.keys(this.manageData)) {
                 let { resource, action, range, param } = JSON.parse(key)
@@ -205,10 +208,13 @@ export default {
             }
 
             await axios.patch(`role/${this.roletag}`, {
+                name: this.rolename,
                 perms,
             })
 
             this.changed = false
+
+            this.$emit('change')
 
             this.isLoading = false
         },

--- a/frontend/src/components/manage/RolePermEdit.vue
+++ b/frontend/src/components/manage/RolePermEdit.vue
@@ -1,5 +1,11 @@
 <template>
-    <v-card tile minHeight="95%" :loading="isLoading" :disabled="disabled">
+    <v-card
+        tile
+        minHeight="95%"
+        :loading="isLoading"
+        :disabled="disabled"
+        outlined
+    >
         <v-toolbar flat>
             <v-toolbar-title>
                 설정

--- a/frontend/src/views/Manage/RoleManage.vue
+++ b/frontend/src/views/Manage/RoleManage.vue
@@ -27,7 +27,7 @@
                 v-show="!isMobileMode || curTab == 0"
                 class="fill-screen"
             >
-                <v-card tile minHeight="95%" :loading="isLoading">
+                <v-card tile minHeight="95%" :loading="isLoading" outlined>
                     <v-card-title>역할</v-card-title>
                     <v-list>
                         <!-- <v-subheader>역할</v-subheader> -->
@@ -69,7 +69,7 @@
                                     </v-list-item-title>
                                 </v-list-item>
                             </template>
-                            <v-card :loading="roleAddDialog.isLoading">
+                            <v-card :loading="roleAddDialog.isLoading" outlined>
                                 <v-card-title class="pb-0">
                                     <v-text-field
                                         label="역할 이름"
@@ -122,7 +122,12 @@
                 v-show="!isMobileMode || curTab == 2"
                 class="fill-height"
             >
-                <v-card :loading="curUsers.isLoading" tile minHeight="95%">
+                <v-card
+                    :loading="curUsers.isLoading"
+                    tile
+                    minHeight="95%"
+                    outlined
+                >
                     <v-toolbar flat>
                         <v-toolbar-title>
                             소속 유저

--- a/frontend/src/views/Manage/RoleManage.vue
+++ b/frontend/src/views/Manage/RoleManage.vue
@@ -27,11 +27,11 @@
                 v-show="!isMobileMode || curTab == 0"
                 class="fill-screen"
             >
-                <v-card tile minHeight="95%">
+                <v-card tile minHeight="95%" :loading="isLoading">
                     <v-card-title>역할</v-card-title>
                     <v-list>
                         <!-- <v-subheader>역할</v-subheader> -->
-                        <template v-if="isLoading">
+                        <template v-if="isLoading && roles.length == 0">
                             <v-skeleton-loader
                                 v-for="i in 7"
                                 :key="`role-loading-${i}`"
@@ -111,6 +111,7 @@
                     :roletag="curRole.tag"
                     :disabled="!$perm('role').can('modify')"
                     @removed="roleRemoved()"
+                    @change="fetchRoles()"
                 ></role-perm-edit>
             </v-col>
 

--- a/frontend/src/views/Manage/UserManage.vue
+++ b/frontend/src/views/Manage/UserManage.vue
@@ -18,6 +18,7 @@
                         hide-details
                         dense
                         label="검색하기"
+                        prepend-inner-icon="mdi-magnify"
                     ></v-text-field>
                 </v-toolbar>
             </template>
@@ -45,7 +46,7 @@
                         cols="12"
                         md="6"
                     >
-                        <v-card>
+                        <v-card outlined>
                             <v-card-title>
                                 <p class="subheader">
                                     {{ user.username }}


### PR DESCRIPTION
## 요약
역할-권한 시스템에서 default 역할에 할당된 권한들은 절대로 끌 수 없는 문제가 발생해, default 역할의 동작을 재설계했다.

## 기존의 문제
기존에는 default 역할은 명시적으로 존재하지 않고, `backend/src/utils/role/default.js` 에 정의된 권한을 모든 권한 체크 단계에서 권한이 있다고 판단하는 방식으로 작동했다. 그러나 현재 역할-권한 시스템 구조상 역할 중에서 OR 연산처럼 대상 권한이 하나라도 있으면 권한이 있다고 판단한다. 따라서 기존 구조에서는 default 역할에 정의된 권한은 모든 유저가 무조건 부여받게 되고, 이를 관리자가 해제할 수 없었다.

## 해결 방법
Default 역할을 다른 역할들처럼 일반적인 역할로 취급한다. 그러나 default 역할은 직접 보이진 않지만 모든 유저에게 기본적으로 할당된다. Default 역할은 관리자가 임의로 삭제할 수 없다. `backend/src/utils/role/default.js` 에 정의된 권한은 처음 서버를 가동할 때 default 역할에 부여되고, 이는 나중에 변경할 수 있다.

## 다른 변경 사항
- 관리 페이지들의 Card 모양을 outlined 로 변경했다.
- 상단 메인바의 elevation 을 낮췄다.
- 역할 이름을 변경할 수 없는 버그를 수정했다.
- 유저의 역할을 해제할 수 없는 버그를 수정했다.
