### PR TITLE
Core: Add details to manage pages

### DIFF
--- a/backend/src/api/v1/auth.route.js
+++ b/backend/src/api/v1/auth.route.js
@@ -142,7 +142,10 @@ router.route('/edittoken/check').post(
     asyncRoute(async (req, res) => {
         try {
             const decoded = await auth.checkToken(req.body.edittoken)
-            if (decoded.is_edit_token) {
+            if (
+                decoded.is_edit_token &&
+                decoded.username === req.user.username
+            ) {
                 res.status(200).end()
             }
         } catch (err) {

--- a/backend/src/api/v1/config.route.js
+++ b/backend/src/api/v1/config.route.js
@@ -1,10 +1,13 @@
 import { Router } from 'express'
 import { asyncRoute, validateParams } from '../../utils/api'
+import { loginRequired } from '../../utils/auth'
+import { getRoleMiddleware } from '../../utils/role'
 import { perm } from '../../utils/role'
 import { body } from 'express-validator'
 import { getConfig, setConfig } from '../../utils/config'
 
 const router = Router()
+router.loginNotRequired = true
 
 const configNames = ['groupName']
 
@@ -36,7 +39,7 @@ router.get(
 // 서버 전체 설정을 가져온다.
 router.get(
     '/admin',
-    [perm('serverConfig').can('change')],
+    [loginRequired, getRoleMiddleware, perm('serverConfig').can('change')],
     asyncRoute(async (req, res) => {
         const configs = {}
 
@@ -53,6 +56,8 @@ router.get(
 router.patch(
     '/admin',
     [
+        loginRequired,
+        getRoleMiddleware,
         perm('serverConfig').can('change'),
         changeableConfigs.map(config => config.check),
         validateParams,

--- a/backend/src/api/v1/user.route.js
+++ b/backend/src/api/v1/user.route.js
@@ -70,7 +70,7 @@ router.delete(
     [param('username').custom(checkUsername), validateParams],
     asyncRoute(async (req, res) => {
         if (
-            !role.perm('user').can('delete') &&
+            !role.perm('manageUsers').can('access') &&
             req.params.username === req.user.username
         ) {
             const err = new Error('권한이 없습니다.')

--- a/backend/src/api/v1/user.route.js
+++ b/backend/src/api/v1/user.route.js
@@ -65,6 +65,27 @@ router.route('/').get(
     })
 )
 
+router.delete(
+    '/:username',
+    [param('username').custom(checkUsername), validateParams],
+    asyncRoute(async (req, res) => {
+        if (
+            !role.perm('user').can('delete') &&
+            req.params.username === req.user.username
+        ) {
+            const err = new Error('권한이 없습니다.')
+            err.status = 403
+            throw err
+        }
+
+        const user = await User.findOne()
+            .where('username')
+            .equals(req.params.username)
+        await user.remove()
+        res.status(200).end()
+    })
+)
+
 router.get(
     '/:username/role',
     [

--- a/backend/src/utils/role/default.js
+++ b/backend/src/utils/role/default.js
@@ -34,6 +34,9 @@ export function setAdminRole(roles) {
         .resource('profile')
         .can(['read', 'update'])
 
+        .resource('user')
+        .can(['delete'])
+
         .resource('role')
         .can(['read', 'modify'])
 

--- a/backend/src/utils/role/permissions.js
+++ b/backend/src/utils/role/permissions.js
@@ -7,7 +7,8 @@ export default {
         {
             type: 'switch',
             title: '유저 관리',
-            content: '유저의 비밀번호를 초기화하거나, 탈퇴시킬 수 있습니다.',
+            content:
+                '유저의 비밀번호를 초기화하거나, 강제 탈퇴시킬 수 있습니다.',
             target: {
                 resource: 'manageUsers',
                 action: 'access',

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,10 +44,10 @@ export default {
     },
     async created() {
         this.isLoading = true
+        await this.$store.dispatch('config/fetchConfig')
 
         if (this.$store.getters['auth/isLoggedIn']) {
             try {
-                await this.$store.dispatch('config/fetchConfig')
                 await this.$store.dispatch('role/fetchPermission')
                 await this.$store.dispatch('board/fetchBoards')
             } catch (error) {

--- a/frontend/src/components/manage/RolePermEdit.vue
+++ b/frontend/src/components/manage/RolePermEdit.vue
@@ -11,6 +11,18 @@
                 설정
             </v-toolbar-title>
             <v-spacer></v-spacer>
+
+            <v-tooltip bottom>
+                <template v-slot:activator="{ on }">
+                    <v-fade-transition>
+                        <v-icon v-show="roletag === 'admin'" v-on="on">
+                            mdi-lock-outline
+                        </v-icon>
+                    </v-fade-transition>
+                </template>
+                <span>관리자 역할의 권한은 변경할 수 없습니다.</span>
+            </v-tooltip>
+
             <v-fade-transition>
                 <v-btn
                     v-if="changed"

--- a/frontend/src/views/Manage/RoleManage.vue
+++ b/frontend/src/views/Manage/RoleManage.vue
@@ -47,10 +47,10 @@
                                     curTab = 1
                                 "
                             >
-                                <v-list-item-content
-                                    ><v-list-item-title>{{
-                                        role.name
-                                    }}</v-list-item-title>
+                                <v-list-item-content>
+                                    <v-list-item-title>
+                                        {{ role.name }}
+                                    </v-list-item-title>
                                 </v-list-item-content>
                             </v-list-item>
                         </v-list-item-group>
@@ -108,6 +108,7 @@
                 class="fill-screen"
             >
                 <role-perm-edit
+                    v-if="curRole.tag"
                     :roletag="curRole.tag"
                     :disabled="!$perm('role').can('modify')"
                     @removed="roleRemoved()"

--- a/frontend/src/views/Manage/UserManage.vue
+++ b/frontend/src/views/Manage/UserManage.vue
@@ -93,7 +93,7 @@
         </v-data-iterator>
 
         <!-- 유저 Action Dialog -->
-        <v-dialog v-model="editDialog.show" persistent max-width="500px">
+        <v-dialog v-model="editDialog.show" persistent max-width="600px">
             <v-card>
                 <v-card-title>
                     <span class="headline">유저 관리</span
@@ -102,11 +102,36 @@
                     }}</v-card-subtitle>
                 </v-card-title>
                 <v-card-text>
-                    <v-container>
+                    <v-divider />
+                    <v-list subheader>
+                        <v-list-item two-line>
+                            <v-list-item-content>
+                                <v-list-item-title>회원탈퇴</v-list-item-title>
+                                <v-list-item-subtitle>
+                                    유저가 작성했던 게시글 등은 삭제되지
+                                    않습니다.
+                                </v-list-item-subtitle>
+                            </v-list-item-content>
+                            <v-list-item-action>
+                                <v-btn
+                                    @click="
+                                        deleteUser(editDialog.user.username)
+                                    "
+                                    color="error"
+                                    depressed
+                                    >회원탈퇴</v-btn
+                                >
+                            </v-list-item-action>
+                        </v-list-item>
+                    </v-list>
+                    <v-divider />
+                    <!-- <v-container>
                         <v-row no-gutters>
-                            <v-col cols="12"> </v-col>
+                            <v-col cols="12">
+                                <v-btn color="error" depressed>회원탈퇴</v-btn>
+                            </v-col>
                         </v-row>
-                    </v-container>
+                    </v-container> -->
                 </v-card-text>
                 <v-card-actions>
                     <v-spacer></v-spacer>
@@ -287,6 +312,31 @@ export default {
             this.roleDialog.selections = []
             this.roleDialog.errorMessage = ''
             this.roleDialog.show = false
+        },
+        async deleteUser(username) {
+            const reply = await this.$action.showConfirmDialog(
+                '회원 탈퇴',
+                `정말 ${username} 유저를 탈퇴시키겠습니까?`
+            )
+            if (reply) {
+                try {
+                    await axios.delete(`user/${username}`)
+                    this.editDialog.show = false
+                    await Promise.all([
+                        this.$action.showAlertDialog(
+                            '회원 탈퇴',
+                            `${username} 유저가 탈퇴 처리되었습니다.`
+                        ),
+                        this.fetchUsers(),
+                    ])
+                } catch (err) {
+                    console.log(err)
+                    await this.$action.showAlertDialog(
+                        '오류',
+                        '탈퇴에 실패했습니다.'
+                    )
+                }
+            }
         },
     },
     async created() {

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -2,8 +2,12 @@
     <v-app>
         <v-app-bar app clipped-left>
             <!-- <v-app-bar-nav-icon @click.stop="drawer = !drawer" /> -->
-            <v-btn text to="/"> <v-toolbar-title>EZSET</v-toolbar-title> </v-btn
-            >회원가입
+            <v-btn text to="/">
+                <v-toolbar-title>
+                    {{ $store.state.config.groupName }}
+                </v-toolbar-title>
+            </v-btn>
+            회원가입
         </v-app-bar>
         <v-content>
             <v-container>


### PR DESCRIPTION
## 요약
관리 페이지들의 디테일을 수정하고, 버그를 수정했다.

## 변경 사항
- 마이페이지에서 다른 사람의 edit token 으로 회원 정보 변경을 할 수 있던 취약점 수정
- 유저 관리 페이지에서 유저 강제 탈퇴기능 추가
- 로그인 하지 않을 시, 서버 설정을 가져올 수 없었던 문제 수정
- 역할 관리 페이지에서 어드민 권한은 수정할 수 없다는 알림 아이콘 추가
- 역할 관리 페이지에서 발생하던 초기화 오류 수정